### PR TITLE
Fix for error made from use of '%' in ser.rs

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1611,7 +1611,7 @@ impl<'a> Deserializer<'a> {
         }
     }
 
-    fn integer(&self, s: &'a str, radix: u32) -> Result<i64, Error> {
+    fn integer(&self, s: &'a str, radix: u32) -> Result<u64, Error> {
         let allow_sign = radix == 10;
         let allow_leading_zeros = radix != 10;
         let (prefix, suffix) = self.parse_integer(s, allow_sign, allow_leading_zeros, radix)?;
@@ -1619,7 +1619,7 @@ impl<'a> Deserializer<'a> {
         if suffix != "" {
             return Err(self.error(start, ErrorKind::NumberInvalid));
         }
-        i64::from_str_radix(&prefix.replace("_", "").trim_start_matches('+'), radix)
+        u64::from_str_radix(&prefix.replace("_", "").trim_start_matches('+'), radix)
             .map_err(|_e| self.error(start, ErrorKind::NumberInvalid))
     }
 
@@ -2231,7 +2231,7 @@ struct Value<'a> {
 
 #[derive(Debug)]
 enum E<'a> {
-    Integer(i64),
+    Integer(u64),
     Float(f64),
     Boolean(bool),
     String(Cow<'a, str>),

--- a/src/de.rs
+++ b/src/de.rs
@@ -807,7 +807,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
     {
         let start = self.value.start;
         let res = match self.value.e {
-            E::Integer(i) => visitor.visit_i64(i),
+            E::Integer(i) => visitor.visit_u64(i),
             E::Boolean(b) => visitor.visit_bool(b),
             E::Float(f) => visitor.visit_f64(f),
             E::String(Cow::Borrowed(s)) => visitor.visit_borrowed_str(s),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -766,7 +766,7 @@ macro_rules! serialize_float {
         } else {
             write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
-        if $v - $v as i32 == 0.0 {
+        if $v - ($v as i32) as f32 == 0.0 {
             write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -766,7 +766,7 @@ macro_rules! serialize_float {
         } else {
             write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
-        if $v % 1.0 == 0.0 {
+        if $v.round() == $v {
             write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -766,7 +766,7 @@ macro_rules! serialize_float {
         } else {
             write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
-        if $v - ($v as i32) as f32 == 0.0 {
+        if $v - ($v as i64) as f64 == 0.0 {
             write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -766,7 +766,11 @@ macro_rules! serialize_float {
         } else {
             write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
-        if remainder($v) == 0.0 {
+        let mut a = $v;
+        while a > 1.0 {
+            a = a - 1.0;
+        }
+        if a == 0.0 {
             write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {
@@ -774,22 +778,6 @@ macro_rules! serialize_float {
         }
         return Ok(());
     }};
-}
-
-fn remainder(input: f32) -> f32 {
-    let mut v = input;
-    while v > 1.0 {
-        v - 1.0;
-    }
-    return v;
-}
-
-fn remainder(input: f64) -> f64 {
-    let mut v = input;
-    while v > 1.0 {
-        v - 1.0;
-    }
-    return v;
 }
 
 impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -766,7 +766,7 @@ macro_rules! serialize_float {
         } else {
             write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
-        if $v.round() == $v {
+        if $v - $v as i32 == 0.0 {
             write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -766,7 +766,7 @@ macro_rules! serialize_float {
         } else {
             write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
-        if $v - ($v as i64) as f64 == 0.0 {
+        if remainder($v) == 0.0 {
             write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {
@@ -774,6 +774,22 @@ macro_rules! serialize_float {
         }
         return Ok(());
     }};
+}
+
+fn remainder(input: f32) -> f32 {
+    let mut v = input;
+    while v > 1.0 {
+        v - 1.0;
+    }
+    return v;
+}
+
+fn remainder(input: f64) -> f64 {
+    let mut v = input;
+    while v > 1.0 {
+        v - 1.0;
+    }
+    return v;
 }
 
 impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {


### PR DESCRIPTION
Hey, I have been working on a small UEFI bootloader. In order to deserialize TOML in a no_std UEFI environment, I had to use this no_std compatible fork. One minor issue occurred though, as a result of using the modulus symbol in ser.rs, causing a linker error since it could not find "fmod" and "fmodf". I was able to fix this by forking and editing the file, replacing the symbol with a small algorithm. I thought this can be of use to you and others that wish to do the same. Maybe take a small look over it, and see if there is any better way to do it. Thanks for creating the no_std version for this crate!